### PR TITLE
[Feat]: 다중 파일 업로드 진행률 모달 구현

### DIFF
--- a/ChordLululala/Utils/FilePicker.swift
+++ b/ChordLululala/Utils/FilePicker.swift
@@ -10,60 +10,48 @@ import UniformTypeIdentifiers
 import UIKit
 
 struct FilePicker: UIViewControllerRepresentable {
-    var onPicked: (URL) -> Void
+    var onStart: (Int) -> Void
+    var onFileReady: (URL) -> Void
+    var onComplete: () -> Void
 
     func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
         let picker = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.pdf, UTType.png, UTType.jpeg], asCopy: true)
+        picker.allowsMultipleSelection = true
         picker.delegate = context.coordinator
         return picker
     }
-    
+
     func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
-    
+
     func makeCoordinator() -> Coordinator {
-        Coordinator(onPicked: onPicked)
+        Coordinator(onStart: onStart, onFileReady: onFileReady, onComplete: onComplete)
     }
-    
+
     class Coordinator: NSObject, UIDocumentPickerDelegate {
-        var onPicked: (URL) -> Void
-        
-        init(onPicked: @escaping (URL) -> Void) {
-            self.onPicked = onPicked
+        var onStart: (Int) -> Void
+        var onFileReady: (URL) -> Void
+        var onComplete: () -> Void
+
+        init(
+            onStart: @escaping (Int) -> Void,
+            onFileReady: @escaping (URL) -> Void,
+            onComplete: @escaping () -> Void
+        ) {
+            self.onStart = onStart
+            self.onFileReady = onFileReady
+            self.onComplete = onComplete
         }
-        
+
         func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
-            guard let originalURL = urls.first else { return }
-            
-            let ext = originalURL.pathExtension.lowercased()
-            
-            if ext == "pdf" {
-                // PDF 파일이면 그대로 전달
-                onPicked(originalURL)
-            } else if ext == "png" || ext == "jpg" || ext == "jpeg" {
-                // 이미지 파일을 PDF로 변환
-                guard let image = UIImage(contentsOfFile: originalURL.path) else {
-                    print("이미지 로드 실패")
-                    return
-                }
-                
-                let pdfRenderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: image.size))
-                let pdfData = pdfRenderer.pdfData { context in
-                    context.beginPage()
-                    image.draw(in: CGRect(origin: .zero, size: image.size))
-                }
-                
-                // 임시 파일에 PDF 데이터 저장
-                let tempDir = FileManager.default.temporaryDirectory
-                let pdfURL = tempDir.appendingPathComponent(UUID().uuidString).appendingPathExtension("pdf")
-                do {
-                    try pdfData.write(to: pdfURL)
-                    onPicked(pdfURL)
-                } catch {
-                    print("PDF 데이터 쓰기 에러: \(error)")
-                }
-            } else {
-                print("지원되지 않는 파일 타입입니다.")
+            guard !urls.isEmpty else { return }
+
+            onStart(urls.count)
+
+            for url in urls {
+                onFileReady(url)
             }
+
+            onComplete()
         }
     }
 }

--- a/ChordLululala/Utils/PhotoPicker.swift
+++ b/ChordLululala/Utils/PhotoPicker.swift
@@ -9,39 +9,67 @@ import SwiftUI
 import PhotosUI
 
 struct PhotoPicker: UIViewControllerRepresentable {
-    var onPicked: (URL) -> Void
-    
+    var onStart: (Int) -> Void
+    var onFileReady: (URL) -> Void
+    var onComplete: () -> Void
+
     func makeUIViewController(context: Context) -> PHPickerViewController {
         var config = PHPickerConfiguration(photoLibrary: .shared())
-        config.selectionLimit = 1
+        config.selectionLimit = 0
         config.filter = .images
 
         let picker = PHPickerViewController(configuration: config)
         picker.delegate = context.coordinator
         return picker
     }
-    
+
     func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
-    
+
     func makeCoordinator() -> Coordinator {
-        Coordinator(onPicked: onPicked)
+        Coordinator(onStart: onStart, onFileReady: onFileReady, onComplete: onComplete)
     }
-    
+
     class Coordinator: NSObject, PHPickerViewControllerDelegate {
-        var onPicked: (URL) -> Void
-        
-        init(onPicked: @escaping (URL) -> Void) {
-            self.onPicked = onPicked
+        var onStart: (Int) -> Void
+        var onFileReady: (URL) -> Void
+        var onComplete: () -> Void
+
+        init(
+            onStart: @escaping (Int) -> Void,
+            onFileReady: @escaping (URL) -> Void,
+            onComplete: @escaping () -> Void
+        ) {
+            self.onStart = onStart
+            self.onFileReady = onFileReady
+            self.onComplete = onComplete
         }
-        
+
         func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
             picker.dismiss(animated: true)
-            
-            guard let itemProvider = results.first?.itemProvider,
-                  itemProvider.canLoadObject(ofClass: UIImage.self) else {
+
+            guard !results.isEmpty else { return }
+
+            DispatchQueue.main.async {
+                self.onStart(results.count)
+            }
+
+            processNextResult(results: results, index: 0)
+        }
+
+        private func processNextResult(results: [PHPickerResult], index: Int) {
+            guard index < results.count else {
+                DispatchQueue.main.async {
+                    self.onComplete()
+                }
                 return
             }
-            
+
+            let itemProvider = results[index].itemProvider
+            guard itemProvider.canLoadObject(ofClass: UIImage.self) else {
+                processNextResult(results: results, index: index + 1)
+                return
+            }
+
             itemProvider.loadObject(ofClass: UIImage.self) { object, error in
                 if let image = object as? UIImage {
                     let pdfRenderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: image.size))
@@ -49,18 +77,20 @@ struct PhotoPicker: UIViewControllerRepresentable {
                         context.beginPage()
                         image.draw(in: CGRect(origin: .zero, size: image.size))
                     }
-                    
+
                     let tempDir = FileManager.default.temporaryDirectory
                     let pdfURL = tempDir.appendingPathComponent(UUID().uuidString).appendingPathExtension("pdf")
                     do {
                         try pdfData.write(to: pdfURL)
                         DispatchQueue.main.async {
-                            self.onPicked(pdfURL)
+                            self.onFileReady(pdfURL)
                         }
                     } catch {
                         print("PDF 저장 실패: \(error)")
                     }
                 }
+
+                self.processNextResult(results: results, index: index + 1)
             }
         }
     }

--- a/ChordLululala/ViewModels/DashBoardViewModels/DashBoardViewModel.swift
+++ b/ChordLululala/ViewModels/DashBoardViewModels/DashBoardViewModel.swift
@@ -144,6 +144,15 @@ final class DashBoardViewModel: ObservableObject {
     @Published var nameOfSetlistCreating: String = ""
     private var preserveCurrentParent: Bool = false
     
+    // MARK: - 업로드 진행률 관련
+    @Published var isUploadingFiles: Bool = false
+    @Published var uploadTotalCount: Int = 0
+    @Published var uploadCompletedCount: Int = 0
+    private var isUploadCancelled: Bool = false
+    private var uploadQueue: [URL] = []
+    private var isProcessingUploadQueue: Bool = false
+    private var isPickerDoneQueuing: Bool = false
+
     // MARK: - 편집&삭제 모달 관련
     @Published var isRenameModalVisible: Bool = false
     @Published var selectedContent: Content? = nil
@@ -331,7 +340,7 @@ final class DashBoardViewModel: ObservableObject {
     
     func uploadFile(with url: URL) {
         guard let parent = currentParent else { return }
-        
+
         ContentManager.shared
             .createScore(with: url, currentParent: parent, dashboardContents: dashboardContents)
             .compactMap { $0 }
@@ -349,6 +358,141 @@ final class DashBoardViewModel: ObservableObject {
                 self?.loadContents()
             }
             .store(in: &cancellables)
+    }
+
+    func prepareUpload(totalCount: Int) {
+        isUploadCancelled = false
+        uploadTotalCount = totalCount
+        uploadCompletedCount = 0
+        isUploadingFiles = true
+        uploadQueue.removeAll()
+        isProcessingUploadQueue = false
+        isPickerDoneQueuing = false
+    }
+
+    func enqueueUploadFile(_ url: URL) {
+        uploadQueue.append(url)
+        if !isProcessingUploadQueue {
+            processNextInQueue()
+        }
+    }
+
+    func markPickerComplete() {
+        isPickerDoneQueuing = true
+        checkUploadCompletion()
+    }
+
+    func cancelUpload() {
+        isUploadCancelled = true
+        isUploadingFiles = false
+        uploadQueue.removeAll()
+        isProcessingUploadQueue = false
+    }
+
+    private func processNextInQueue() {
+        guard !isUploadCancelled else {
+            isUploadingFiles = false
+            loadContents()
+            return
+        }
+
+        guard !uploadQueue.isEmpty else {
+            isProcessingUploadQueue = false
+            checkUploadCompletion()
+            return
+        }
+
+        isProcessingUploadQueue = true
+        let url = uploadQueue.removeFirst()
+
+        let ext = url.pathExtension.lowercased()
+        if ext == "png" || ext == "jpg" || ext == "jpeg" {
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                let pdfURL = self?.convertImageToPDF(imageURL: url)
+                DispatchQueue.main.async {
+                    guard let self = self else { return }
+                    if let pdfURL = pdfURL {
+                        self.performUpload(url: pdfURL)
+                    } else {
+                        self.uploadCompletedCount += 1
+                        self.isProcessingUploadQueue = false
+                        self.processNextInQueue()
+                    }
+                }
+            }
+            return
+        }
+
+        performUpload(url: url)
+    }
+
+    private func performUpload(url: URL) {
+        guard let parent = currentParent else {
+            isProcessingUploadQueue = false
+            isUploadingFiles = false
+            return
+        }
+
+        ContentManager.shared
+            .createScore(with: url, currentParent: parent, dashboardContents: dashboardContents)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newContent in
+                guard let self = self, let newContent = newContent else {
+                    self?.uploadCompletedCount += 1
+                    self?.isProcessingUploadQueue = false
+                    self?.processNextInQueue()
+                    return
+                }
+
+                ScoreDetailManager.shared.createScoreDetail(for: newContent)
+                    .receive(on: DispatchQueue.main)
+                    .sink { [weak self] detail in
+                        guard let self = self else { return }
+
+                        guard let pdfURL = ScoreDetailManager.shared.getContentURL(for: detail) else {
+                            self.uploadCompletedCount += 1
+                            self.isProcessingUploadQueue = false
+                            self.processNextInQueue()
+                            return
+                        }
+
+                        ScorePageManager.shared.createPages(for: detail, fileURL: pdfURL)
+                            .receive(on: DispatchQueue.main)
+                            .sink { [weak self] in
+                                self?.uploadCompletedCount += 1
+                                self?.isProcessingUploadQueue = false
+                                self?.processNextInQueue()
+                            }
+                            .store(in: &self.cancellables)
+                    }
+                    .store(in: &self.cancellables)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func checkUploadCompletion() {
+        if isPickerDoneQueuing && uploadQueue.isEmpty && !isProcessingUploadQueue {
+            isUploadingFiles = false
+            loadContents()
+        }
+    }
+
+    private func convertImageToPDF(imageURL: URL) -> URL? {
+        guard let image = UIImage(contentsOfFile: imageURL.path) else { return nil }
+        let pdfRenderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: image.size))
+        let pdfData = pdfRenderer.pdfData { context in
+            context.beginPage()
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
+        let tempDir = FileManager.default.temporaryDirectory
+        let pdfURL = tempDir.appendingPathComponent(UUID().uuidString).appendingPathExtension("pdf")
+        do {
+            try pdfData.write(to: pdfURL)
+            return pdfURL
+        } catch {
+            print("PDF 변환 실패: \(error)")
+            return nil
+        }
     }
     
     func createFolder(folderName: String) {

--- a/ChordLululala/Views/DashBoardViews/DashBoardView.swift
+++ b/ChordLululala/Views/DashBoardViews/DashBoardView.swift
@@ -140,18 +140,34 @@ struct DashboardView: View {
                 
                 // MARK: 파일 생성 시트 (앨범 Picker)
                 .sheet(isPresented: $viewModel.isAlbumPickerVisible) {
-                    PhotoPicker { pickedURL in
-                        viewModel.uploadFile(with: pickedURL)
-                        viewModel.isAlbumPickerVisible = false
-                    }
+                    PhotoPicker(
+                        onStart: { count in
+                            viewModel.prepareUpload(totalCount: count)
+                            viewModel.isAlbumPickerVisible = false
+                        },
+                        onFileReady: { url in
+                            viewModel.enqueueUploadFile(url)
+                        },
+                        onComplete: {
+                            viewModel.markPickerComplete()
+                        }
+                    )
                 }
-                
+
                 // MARK: 파일 생성 시트 (파일 Picker)
                 .sheet(isPresented: $viewModel.isPDFPickerVisible) {
-                    FilePicker { selectedURL in
-                        viewModel.uploadFile(with: selectedURL)
-                        viewModel.isPDFPickerVisible = false
-                    }
+                    FilePicker(
+                        onStart: { count in
+                            viewModel.prepareUpload(totalCount: count)
+                            viewModel.isPDFPickerVisible = false
+                        },
+                        onFileReady: { url in
+                            viewModel.enqueueUploadFile(url)
+                        },
+                        onComplete: {
+                            viewModel.markPickerComplete()
+                        }
+                    )
                 }
                 // MARK: 셋리스트 생성 모달
                 if viewModel.isCreateSetlistModalVisible {
@@ -261,6 +277,14 @@ struct DashboardView: View {
                     }
                 )
                 .environmentObject(mypageViewModel)
+            }
+
+            // MARK: 파일 업로드 진행률 모달
+            if viewModel.isUploadingFiles {
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea()
+                UploadProgressModalView()
+                    .environmentObject(viewModel)
             }
             
             // MARK: 휴지통 이동 모달

--- a/ChordLululala/Views/DashBoardViews/ModalViews/UploadProgressModalView.swift
+++ b/ChordLululala/Views/DashBoardViews/ModalViews/UploadProgressModalView.swift
@@ -1,0 +1,58 @@
+//
+//  UploadProgressModalView.swift
+//  ChordLululala
+//
+//  Created by Minhyeok Kim on 2/21/26.
+//
+
+import SwiftUI
+
+struct UploadProgressModalView: View {
+    @EnvironmentObject var viewModel: DashBoardViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: 0) {
+                Text("파일 추가 중")
+                    .font(.headingMdSemiBold)
+                    .padding(.top, 18)
+                    .padding(.bottom, 8)
+
+                Text("\(viewModel.uploadTotalCount)개 중 \(viewModel.uploadCompletedCount)개 완료")
+                    .font(.bodyTextLgRegular)
+                    .foregroundColor(.primaryGray500)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom, 18)
+
+                ProgressView(value: viewModel.uploadTotalCount > 0
+                    ? Double(viewModel.uploadCompletedCount) / Double(viewModel.uploadTotalCount)
+                    : 0)
+                    .progressViewStyle(LinearProgressViewStyle())
+                    .frame(height: 9)
+                    .tint(.primaryBlue600)
+                    .padding(.top, 12)
+                    .padding(.bottom, 21)
+                    .padding(.horizontal, 20)
+
+                Rectangle()
+                    .frame(maxWidth: .infinity, maxHeight: 1)
+                    .foregroundColor(Color.primaryGray300)
+
+                HStack(spacing: 0) {
+                    Button(action: {
+                        viewModel.cancelUpload()
+                    }) {
+                        Text("추가 중단")
+                            .font(.headingLgMedium)
+                            .frame(maxWidth: .infinity, maxHeight: 51)
+                    }
+                    .foregroundColor(.supportingRed500)
+                }
+            }
+            .frame(width: 309)
+            .background(Color.white)
+            .cornerRadius(12)
+            .shadow(color: Color.black.opacity(0.15), radius: 10, x: 0, y: 0)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 파일 추가 시 진행률을 보여주는 `UploadProgressModalView` 추가 (BackupProgressModalView 패턴 참고)
- Picker에서 파일별 순차 처리(변환+업로드) 구조로 변경하여 진행률이 실시간 반영
- 업로드 도중 "추가 중단" 버튼으로 취소 가능 (이미 완료된 파일은 유지)

## 변경 파일
- **`UploadProgressModalView.swift`** (신규) — 진행률 모달 UI
- **`DashBoardViewModel.swift`** — 큐 기반 업로드 파이프라인 (prepareUpload, enqueueUploadFile, markPickerComplete, cancelUpload)
- **`PhotoPicker.swift`** — 이미지 순차 처리 + onStart/onFileReady/onComplete 콜백
- **`FilePicker.swift`** — 변환 없이 raw URL 전달 + onStart/onFileReady/onComplete 콜백
- **`DashBoardView.swift`** — 업로드 진행률 모달 오버레이 추가

## Test plan
- [ ] 단일 파일(PDF) 추가 시 모달 표시 → 0% → 100% 진행 확인
- [ ] 앨범에서 이미지 3개 이상 선택 시 파일별로 진행률 증가 확인
- [ ] 파일 앱에서 이미지+PDF 혼합 선택 시 정상 동작 확인
- [ ] 업로드 도중 "추가 중단" 클릭 시 모달 닫히고 완료된 파일만 리스트에 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)