### PR TITLE
[Feat] Share Extension - 외부 앱에서 파일 공유

### DIFF
--- a/ChordLululala.xcodeproj/project.pbxproj
+++ b/ChordLululala.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		160EB9BCC50A4BF5DAD1C014 /* Pods_ChordLululala.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71E971CD1EB430225634557C /* Pods_ChordLululala.framework */; };
 		A39870159B1F0EF8AE77F741 /* Pods_ChordLululalaTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D6BF49E98047D5DE0C900D5 /* Pods_ChordLululalaTests.framework */; };
 		ABE60BF34287B4F30DBBB1C2 /* Pods_ChordLululala_ChordLululalaUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED50743422B50CEFB7851F40 /* Pods_ChordLululala_ChordLululalaUITests.framework */; };
+		DB7CE60A2F49A0080061C6C5 /* ChordLululalaShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DB7CE6002F49A0080061C6C5 /* ChordLululalaShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,7 +28,28 @@
 			remoteGlobalIDString = DB32EEBB2D4CC838008C113B;
 			remoteInfo = ChordLululala;
 		};
+		DB7CE6082F49A0080061C6C5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB32EEB42D4CC838008C113B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DB7CE5FF2F49A0080061C6C5;
+			remoteInfo = ChordLululalaShareExtension;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		DB7CE60F2F49A0080061C6C5 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				DB7CE60A2F49A0080061C6C5 /* ChordLululalaShareExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		050B8E0C49B66B4A8716246D /* Pods-ChordLululalaTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChordLululalaTests.release.xcconfig"; path = "Target Support Files/Pods-ChordLululalaTests/Pods-ChordLululalaTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -41,6 +63,7 @@
 		DB32EEBC2D4CC838008C113B /* ChordLululala.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChordLululala.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB32EED32D4CC83B008C113B /* ChordLululalaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChordLululalaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB32EEDD2D4CC83C008C113B /* ChordLululalaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChordLululalaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DB7CE6002F49A0080061C6C5 /* ChordLululalaShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ChordLululalaShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED50743422B50CEFB7851F40 /* Pods_ChordLululala_ChordLululalaUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ChordLululala_ChordLululalaUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -51,6 +74,13 @@
 				Info.plist,
 			);
 			target = DB32EEBB2D4CC838008C113B /* ChordLululala */;
+		};
+		DB7CE60E2F49A0080061C6C5 /* Exceptions for "ChordLululalaShareExtension" folder in "ChordLululalaShareExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = DB7CE5FF2F49A0080061C6C5 /* ChordLululalaShareExtension */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -65,16 +95,20 @@
 		};
 		DB32EED62D4CC83C008C113B /* ChordLululalaTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = ChordLululalaTests;
 			sourceTree = "<group>";
 		};
 		DB32EEE02D4CC83C008C113B /* ChordLululalaUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = ChordLululalaUITests;
+			sourceTree = "<group>";
+		};
+		DB7CE6012F49A0080061C6C5 /* ChordLululalaShareExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				DB7CE60E2F49A0080061C6C5 /* Exceptions for "ChordLululalaShareExtension" folder in "ChordLululalaShareExtension" target */,
+			);
+			path = ChordLululalaShareExtension;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -101,6 +135,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				ABE60BF34287B4F30DBBB1C2 /* Pods_ChordLululala_ChordLululalaUITests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB7CE5FD2F49A0080061C6C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -136,6 +177,7 @@
 				DB32EEBE2D4CC838008C113B /* ChordLululala */,
 				DB32EED62D4CC83C008C113B /* ChordLululalaTests */,
 				DB32EEE02D4CC83C008C113B /* ChordLululalaUITests */,
+				DB7CE6012F49A0080061C6C5 /* ChordLululalaShareExtension */,
 				DB32EEBD2D4CC838008C113B /* Products */,
 				D8CC04D83FCE88E1AA9C7BFF /* Pods */,
 				C99EA8D5E3D7958B3F0CB69E /* Frameworks */,
@@ -148,6 +190,7 @@
 				DB32EEBC2D4CC838008C113B /* ChordLululala.app */,
 				DB32EED32D4CC83B008C113B /* ChordLululalaTests.xctest */,
 				DB32EEDD2D4CC83C008C113B /* ChordLululalaUITests.xctest */,
+				DB7CE6002F49A0080061C6C5 /* ChordLululalaShareExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -165,10 +208,12 @@
 				DB32EEBA2D4CC838008C113B /* Resources */,
 				459C108A283D30D123490EA3 /* [CP] Embed Pods Frameworks */,
 				77E39C312BFAFA703EE25F3A /* [CP] Copy Pods Resources */,
+				DB7CE60F2F49A0080061C6C5 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				DB7CE6092F49A0080061C6C5 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				DB32EEBE2D4CC838008C113B /* ChordLululala */,
@@ -224,6 +269,28 @@
 			productReference = DB32EEDD2D4CC83C008C113B /* ChordLululalaUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		DB7CE5FF2F49A0080061C6C5 /* ChordLululalaShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DB7CE60B2F49A0080061C6C5 /* Build configuration list for PBXNativeTarget "ChordLululalaShareExtension" */;
+			buildPhases = (
+				DB7CE5FC2F49A0080061C6C5 /* Sources */,
+				DB7CE5FD2F49A0080061C6C5 /* Frameworks */,
+				DB7CE5FE2F49A0080061C6C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				DB7CE6012F49A0080061C6C5 /* ChordLululalaShareExtension */,
+			);
+			name = ChordLululalaShareExtension;
+			packageProductDependencies = (
+			);
+			productName = ChordLululalaShareExtension;
+			productReference = DB7CE6002F49A0080061C6C5 /* ChordLululalaShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -231,7 +298,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1610;
+				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1610;
 				TargetAttributes = {
 					DB32EEBB2D4CC838008C113B = {
@@ -245,6 +312,9 @@
 					DB32EEDC2D4CC83C008C113B = {
 						CreatedOnToolsVersion = 16.1;
 						TestTargetID = DB32EEBB2D4CC838008C113B;
+					};
+					DB7CE5FF2F49A0080061C6C5 = {
+						CreatedOnToolsVersion = 16.2;
 					};
 				};
 			};
@@ -265,6 +335,7 @@
 				DB32EEBB2D4CC838008C113B /* ChordLululala */,
 				DB32EED22D4CC83B008C113B /* ChordLululalaTests */,
 				DB32EEDC2D4CC83C008C113B /* ChordLululalaUITests */,
+				DB7CE5FF2F49A0080061C6C5 /* ChordLululalaShareExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -285,6 +356,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		DB32EEDB2D4CC83C008C113B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB7CE5FE2F49A0080061C6C5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -452,6 +530,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DB7CE5FC2F49A0080061C6C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -464,6 +549,11 @@
 			isa = PBXTargetDependency;
 			target = DB32EEBB2D4CC838008C113B /* ChordLululala */;
 			targetProxy = DB32EEDE2D4CC83C008C113B /* PBXContainerItemProxy */;
+		};
+		DB7CE6092F49A0080061C6C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DB7CE5FF2F49A0080061C6C5 /* ChordLululalaShareExtension */;
+			targetProxy = DB7CE6082F49A0080061C6C5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -746,6 +836,64 @@
 			};
 			name = Release;
 		};
+		DB7CE60C2F49A0080061C6C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ChordLululalaShareExtension/ChordLululalaShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 55JW9PZ4J9;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChordLululalaShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ChordLululalaShareExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.minzzzun.NoteFlow.ChordLululalaShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DB7CE60D2F49A0080061C6C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ChordLululalaShareExtension/ChordLululalaShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 55JW9PZ4J9;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChordLululalaShareExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ChordLululalaShareExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.minzzzun.NoteFlow.ChordLululalaShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -781,6 +929,15 @@
 			buildConfigurations = (
 				DB32EEEF2D4CC83C008C113B /* Debug */,
 				DB32EEF02D4CC83C008C113B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DB7CE60B2F49A0080061C6C5 /* Build configuration list for PBXNativeTarget "ChordLululalaShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DB7CE60C2F49A0080061C6C5 /* Debug */,
+				DB7CE60D2F49A0080061C6C5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ChordLululala/ChordLululala.entitlements
+++ b/ChordLululala/ChordLululala.entitlements
@@ -20,6 +20,10 @@
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.noteflow.chordlululala</string>
+	</array>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 </dict>

--- a/ChordLululala/Info.plist
+++ b/ChordLululala/Info.plist
@@ -10,6 +10,14 @@
 				<string>com.googleusercontent.apps.550403410377-521r9ton3t3n3ghln98h1s1tfmcghss7</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>chordlululala</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>com.noteflow.chordlululala</string>
+		</dict>
 	</array>
 	<key>GIDClientID</key>
 	<string>550403410377-521r9ton3t3n3ghln98h1s1tfmcghss7.apps.googleusercontent.com</string>

--- a/ChordLululala/Managers/SharedInboxManager.swift
+++ b/ChordLululala/Managers/SharedInboxManager.swift
@@ -1,0 +1,214 @@
+//
+//  SharedInboxManager.swift
+//  ChordLululala
+//
+//  Created by Minhyeok Kim on 2/21/26.
+//
+
+import Foundation
+import Combine
+import CoreData
+import UIKit
+
+final class SharedInboxManager {
+    static let shared = SharedInboxManager()
+    private let appGroupID = "group.com.noteflow.chordlululala"
+    private var context: NSManagedObjectContext { CoreDataManager.shared.context }
+
+    private init() {}
+
+    private var sharedInboxURL: URL? {
+        FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: appGroupID)?
+            .appendingPathComponent("SharedInbox", isDirectory: true)
+    }
+
+    func importSharedInboxFiles() -> AnyPublisher<Bool, Never> {
+        Future<Bool, Never> { [weak self] promise in
+            guard let self = self,
+                  let inboxURL = self.sharedInboxURL else {
+                promise(.success(false))
+                return
+            }
+
+            let fileManager = FileManager.default
+
+            // SharedInbox 폴더가 없으면 생성 후 빈 상태로 종료
+            if !fileManager.fileExists(atPath: inboxURL.path) {
+                try? fileManager.createDirectory(at: inboxURL, withIntermediateDirectories: true)
+                promise(.success(false))
+                return
+            }
+
+            guard let items = try? fileManager.contentsOfDirectory(
+                at: inboxURL,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ), !items.isEmpty else {
+                promise(.success(false))
+                return
+            }
+
+            // Score 베이스 디렉토리 가져오기
+            guard let scoreBase = ContentCoreDataManager.shared.fetchBaseDirectory(named: "Score"),
+                  let docsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+                promise(.success(false))
+                return
+            }
+
+            let scoreDir = docsURL.appendingPathComponent("Score", isDirectory: true)
+            try? fileManager.createDirectory(at: scoreDir, withIntermediateDirectories: true)
+
+            let now = Date()
+            var importedCount = 0
+
+            for fileURL in items {
+                let ext = fileURL.pathExtension.lowercased()
+
+                if ["jpg", "jpeg", "png", "heic"].contains(ext) {
+                    // 이미지 → PDF 변환 후 Score/에 저장
+                    guard let image = UIImage(contentsOfFile: fileURL.path) else {
+                        try? fileManager.removeItem(at: fileURL)
+                        continue
+                    }
+
+                    let baseName = (fileURL.deletingPathExtension().lastPathComponent)
+                    let pdfName = self.uniqueFileName(baseName + ".pdf", in: scoreDir)
+                    let pdfRelPath = "Score/\(pdfName)"
+                    let pdfDestURL = scoreDir.appendingPathComponent(pdfName)
+
+                    let pdfRenderer = UIGraphicsPDFRenderer(
+                        bounds: CGRect(origin: .zero, size: image.size)
+                    )
+                    let pdfData = pdfRenderer.pdfData { ctx in
+                        ctx.beginPage()
+                        image.draw(in: CGRect(origin: .zero, size: image.size))
+                    }
+
+                    do {
+                        try pdfData.write(to: pdfDestURL)
+                    } catch {
+                        print("❌ [SharedInbox] 이미지 → PDF 변환 실패: \(error)")
+                        try? fileManager.removeItem(at: fileURL)
+                        continue
+                    }
+
+                    // Core Data 엔티티 생성
+                    self.createScoreEntities(
+                        name: pdfName,
+                        path: pdfRelPath,
+                        pdfURL: pdfDestURL,
+                        parent: scoreBase,
+                        now: now
+                    )
+                    importedCount += 1
+                    print("🖼️→📄 [SharedInbox] \(fileURL.lastPathComponent) → \(pdfName)")
+
+                    // SharedInbox에서 삭제
+                    try? fileManager.removeItem(at: fileURL)
+
+                } else if ext == "pdf" {
+                    // PDF → Score/에 복사
+                    let pdfName = self.uniqueFileName(fileURL.lastPathComponent, in: scoreDir)
+                    let pdfRelPath = "Score/\(pdfName)"
+                    let pdfDestURL = scoreDir.appendingPathComponent(pdfName)
+
+                    do {
+                        try fileManager.copyItem(at: fileURL, to: pdfDestURL)
+                    } catch {
+                        print("❌ [SharedInbox] PDF 복사 실패: \(error)")
+                        try? fileManager.removeItem(at: fileURL)
+                        continue
+                    }
+
+                    // Core Data 엔티티 생성
+                    self.createScoreEntities(
+                        name: pdfName,
+                        path: pdfRelPath,
+                        pdfURL: pdfDestURL,
+                        parent: scoreBase,
+                        now: now
+                    )
+                    importedCount += 1
+                    print("📄 [SharedInbox] PDF 추가: \(pdfRelPath)")
+
+                    // SharedInbox에서 삭제
+                    try? fileManager.removeItem(at: fileURL)
+
+                } else {
+                    // 지원하지 않는 파일 형식은 삭제
+                    try? fileManager.removeItem(at: fileURL)
+                }
+            }
+
+            if importedCount > 0 {
+                do {
+                    try self.context.save()
+                    print("✅ [SharedInbox] context.save() 완료 (\(importedCount)개 파일)")
+                } catch {
+                    print("❌ [SharedInbox] CoreData 저장 오류: \(error)")
+                }
+            }
+
+            promise(.success(importedCount > 0))
+        }
+        .eraseToAnyPublisher()
+    }
+
+    private func createScoreEntities(
+        name: String,
+        path: String,
+        pdfURL: URL,
+        parent: Content,
+        now: Date
+    ) {
+        let fileContent = Content(context: context)
+        fileContent.id = UUID()
+        fileContent.name = name
+        fileContent.path = path
+        fileContent.type = ContentType.score.rawValue
+        fileContent.createdAt = now
+        fileContent.modifiedAt = now
+        fileContent.lastAccessedAt = now
+        fileContent.deletedAt = nil
+        fileContent.isStared = false
+        fileContent.syncStatus = false
+        fileContent.parentContent = parent
+
+        let detail = ScoreDetail(context: context)
+        detail.id = UUID()
+        detail.key = ""
+        detail.t_key = ""
+        detail.content = fileContent
+        fileContent.scoreDetail = detail
+
+        let pageCount = getPDFPageCount(url: pdfURL)
+        for i in 0..<pageCount {
+            let page = ScorePage(context: context)
+            page.id = UUID()
+            page.pageType = "pdf"
+            page.originalPageIndex = Int16(i)
+            page.displayOrder = Int16(i)
+            page.scoreDetail = detail
+        }
+    }
+
+    private func getPDFPageCount(url: URL) -> Int {
+        guard let doc = CGPDFDocument(url as CFURL) else { return 0 }
+        return doc.numberOfPages
+    }
+
+    private func uniqueFileName(_ name: String, in directory: URL) -> String {
+        let fileManager = FileManager.default
+        let baseName = (name as NSString).deletingPathExtension
+        let ext = (name as NSString).pathExtension
+
+        var candidate = name
+        var counter = 1
+        while fileManager.fileExists(atPath: directory.appendingPathComponent(candidate).path) {
+            candidate = ext.isEmpty ? "\(baseName)_\(counter)" : "\(baseName)_\(counter).\(ext)"
+            counter += 1
+        }
+        return candidate
+    }
+}

--- a/ChordLululala/ViewModels/DashBoardViewModels/DashBoardViewModel.swift
+++ b/ChordLululala/ViewModels/DashBoardViewModels/DashBoardViewModel.swift
@@ -191,8 +191,9 @@ final class DashBoardViewModel: ObservableObject {
         }
         
         importFromDropboxAndLoadContents()
+        importFromSharedInbox()
     }
-    
+
     func goToSetlistPreservingFolder() {
         preserveCurrentParent = true
         dashboardContents = .setlist
@@ -730,13 +731,25 @@ final class DashBoardViewModel: ObservableObject {
         guard let parent = currentParent else {
             return
         }
-        
+
         return DropboxImportManager.shared
             .syncCurrentFolderWithFileSystem(parent: parent)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.loadContents()
                 self?.loadMoveDestinations()
+            }
+            .store(in: &cancellables)
+    }
+
+    func importFromSharedInbox() {
+        SharedInboxManager.shared.importSharedInboxFiles()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] didImport in
+                if didImport {
+                    self?.loadContents()
+                    self?.loadMoveDestinations()
+                }
             }
             .store(in: &cancellables)
     }

--- a/ChordLululala/Views/DashBoardViews/DashBoardView.swift
+++ b/ChordLululala/Views/DashBoardViews/DashBoardView.swift
@@ -327,6 +327,7 @@ struct DashboardView: View {
             .navigationBarHidden(true)
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
                 viewModel.importFromDropboxAndLoadContents()
+                viewModel.importFromSharedInbox()
             }
     }
     

--- a/ChordLululalaShareExtension/ChordLululalaShareExtension.entitlements
+++ b/ChordLululalaShareExtension/ChordLululalaShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.noteflow.chordlululala</string>
+	</array>
+</dict>
+</plist>

--- a/ChordLululalaShareExtension/Info.plist
+++ b/ChordLululalaShareExtension/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>10</integer>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>10</integer>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ChordLululalaShareExtension/ShareExtensionView.swift
+++ b/ChordLululalaShareExtension/ShareExtensionView.swift
@@ -1,0 +1,193 @@
+//
+//  ShareExtensionView.swift
+//  ChordLululalaShareExtension
+//
+//  Created by Minhyeok Kim on 2/21/26.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ShareExtensionView: View {
+    weak var extensionContext: NSExtensionContext?
+
+    @State private var fileNames: [String] = []
+    @State private var itemProviders: [NSItemProvider] = []
+    @State private var isSaving = false
+    @State private var saveCompleted = false
+
+    private let appGroupID = "group.com.noteflow.chordlululala"
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                if fileNames.isEmpty && !isSaving {
+                    ProgressView("파일 불러오는 중...")
+                        .padding()
+                } else if saveCompleted {
+                    VStack(spacing: 12) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 48))
+                            .foregroundColor(.green)
+                        Text("업로드 완료")
+                            .font(.headline)
+                    }
+                    .padding()
+                } else {
+                    List {
+                        ForEach(fileNames, id: \.self) { name in
+                            HStack {
+                                Image(systemName: name.hasSuffix(".pdf") ? "doc.fill" : "photo.fill")
+                                    .foregroundColor(.blue)
+                                Text(name)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("NoteFlow")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") {
+                        extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+                    }
+                    .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("업로드") {
+                        saveFiles()
+                    }
+                    .disabled(isSaving || fileNames.isEmpty)
+                }
+            }
+        }
+        .onAppear {
+            loadItemProviders()
+        }
+    }
+
+    private func loadItemProviders() {
+        guard let items = extensionContext?.inputItems as? [NSExtensionItem] else { return }
+
+        var providers: [NSItemProvider] = []
+        for item in items {
+            if let attachments = item.attachments {
+                providers.append(contentsOf: attachments)
+            }
+        }
+        itemProviders = providers
+
+        for provider in providers {
+            if provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier) {
+                provider.loadItem(forTypeIdentifier: UTType.pdf.identifier, options: nil) { item, _ in
+                    let name: String
+                    if let url = item as? URL {
+                        name = url.lastPathComponent
+                    } else {
+                        name = UUID().uuidString + ".pdf"
+                    }
+                    DispatchQueue.main.async {
+                        fileNames.append(name)
+                    }
+                }
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+                let suggestedName = provider.suggestedName
+                provider.loadItem(forTypeIdentifier: UTType.image.identifier, options: nil) { item, _ in
+                    let name: String
+                    if let url = item as? URL {
+                        name = url.lastPathComponent
+                    } else if let suggested = suggestedName {
+                        name = suggested + ".png"
+                    } else {
+                        name = UUID().uuidString + ".png"
+                    }
+                    DispatchQueue.main.async {
+                        fileNames.append(name)
+                    }
+                }
+            }
+        }
+    }
+
+    private func saveFiles() {
+        isSaving = true
+
+        guard let containerURL = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupID
+        ) else {
+            extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+            return
+        }
+
+        let inboxURL = containerURL.appendingPathComponent("SharedInbox", isDirectory: true)
+        try? FileManager.default.createDirectory(at: inboxURL, withIntermediateDirectories: true)
+
+        let group = DispatchGroup()
+
+        for provider in itemProviders {
+            if provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier) {
+                group.enter()
+                provider.loadItem(forTypeIdentifier: UTType.pdf.identifier, options: nil) { item, error in
+                    defer { group.leave() }
+                    guard error == nil else { return }
+
+                    if let url = item as? URL {
+                        let destName = uniqueFileName(url.lastPathComponent, in: inboxURL)
+                        let dest = inboxURL.appendingPathComponent(destName)
+                        try? FileManager.default.copyItem(at: url, to: dest)
+                    } else if let data = item as? Data {
+                        let name = uniqueFileName(UUID().uuidString + ".pdf", in: inboxURL)
+                        let dest = inboxURL.appendingPathComponent(name)
+                        try? data.write(to: dest)
+                    }
+                }
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+                group.enter()
+                provider.loadItem(forTypeIdentifier: UTType.image.identifier, options: nil) { item, error in
+                    defer { group.leave() }
+                    guard error == nil else { return }
+
+                    if let url = item as? URL {
+                        let destName = uniqueFileName(url.lastPathComponent, in: inboxURL)
+                        let dest = inboxURL.appendingPathComponent(destName)
+                        try? FileManager.default.copyItem(at: url, to: dest)
+                    } else if let image = item as? UIImage,
+                              let data = image.pngData() {
+                        let suggestedName = provider.suggestedName ?? UUID().uuidString
+                        let name = uniqueFileName(suggestedName + ".png", in: inboxURL)
+                        let dest = inboxURL.appendingPathComponent(name)
+                        try? data.write(to: dest)
+                    } else if let data = item as? Data {
+                        let suggestedName = provider.suggestedName ?? UUID().uuidString
+                        let name = uniqueFileName(suggestedName + ".png", in: inboxURL)
+                        let dest = inboxURL.appendingPathComponent(name)
+                        try? data.write(to: dest)
+                    }
+                }
+            }
+        }
+
+        group.notify(queue: .main) {
+            saveCompleted = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+            }
+        }
+    }
+
+    private func uniqueFileName(_ name: String, in directory: URL) -> String {
+        let fileManager = FileManager.default
+        let baseName = (name as NSString).deletingPathExtension
+        let ext = (name as NSString).pathExtension
+
+        var candidate = name
+        var counter = 1
+        while fileManager.fileExists(atPath: directory.appendingPathComponent(candidate).path) {
+            candidate = ext.isEmpty ? "\(baseName)_\(counter)" : "\(baseName)_\(counter).\(ext)"
+            counter += 1
+        }
+        return candidate
+    }
+}

--- a/ChordLululalaShareExtension/ShareViewController.swift
+++ b/ChordLululalaShareExtension/ShareViewController.swift
@@ -1,0 +1,30 @@
+//
+//  ShareViewController.swift
+//  ChordLululalaShareExtension
+//
+//  Created by Minhyeok Kim on 2/21/26.
+//
+
+import UIKit
+import SwiftUI
+
+class ShareViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let hostingController = UIHostingController(
+            rootView: ShareExtensionView(extensionContext: extensionContext)
+        )
+
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        hostingController.didMove(toParent: self)
+    }
+}


### PR DESCRIPTION
## Summary
- 외부 앱(사진, 파일, 카카오톡 등)에서 이미지/PDF를 공유할 때 ChordLululala(NoteFlow)로 보낼 수 있는 Share Extension 추가
- App Groups 공유 폴더(SharedInbox) 패턴: Extension이 파일 저장 → 메인 앱 foreground 진입 시 자동 임포트
- 이미지(png/jpg/jpeg/heic)는 PDF로 자동 변환, PDF는 그대로 Score에 등록

## 변경 사항
- **신규**: `ChordLululalaShareExtension/` - ShareViewController, ShareExtensionView, Info.plist
- **신규**: `SharedInboxManager.swift` - DropboxImportManager 패턴 기반 SharedInbox 파일 임포트
- **수정**: `DashBoardViewModel.swift` - `importFromSharedInbox()` 메서드 추가 및 init에서 호출
- **수정**: `DashBoardView.swift` - willEnterForeground 핸들러에 SharedInbox 임포트 추가
- **수정**: `Info.plist` - `chordlululala://` URL Scheme 추가
- **수정**: entitlements - App Groups(`group.com.noteflow.chordlululala`) 설정

## Test plan
- [ ] 사진 앱에서 이미지 1장 공유 → NoteFlow 선택 → 업로드 → 앱 열기 → Score 루트에 PDF로 표시 확인
- [ ] 파일 앱에서 PDF 공유 → 동일 플로우 확인
- [ ] 여러 파일(이미지+PDF 혼합) 동시 공유 → 모두 정상 임포트 확인
- [ ] 중복 파일명 공유 시 `파일명_1.pdf` 형태로 충돌 없이 저장 확인
- [ ] 앱이 이미 foreground 상태에서 공유 후 돌아오면 자동 임포트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)