### PR TITLE
[Feat] Apple Pencil 바로 필기 지원

### DIFF
--- a/ChordLululala.xcodeproj/project.pbxproj
+++ b/ChordLululala.xcodeproj/project.pbxproj
@@ -75,7 +75,7 @@
 			);
 			target = DB32EEBB2D4CC838008C113B /* ChordLululala */;
 		};
-		DB7CE60E2F49A0080061C6C5 /* Exceptions for "ChordLululalaShareExtension" folder in "ChordLululalaShareExtension" target */ = {
+		DB7CE6012F49A0080061C6C6 /* Exceptions for "ChordLululalaShareExtension" folder in "ChordLululalaShareExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -106,7 +106,7 @@
 		DB7CE6012F49A0080061C6C5 /* ChordLululalaShareExtension */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				DB7CE60E2F49A0080061C6C5 /* Exceptions for "ChordLululalaShareExtension" folder in "ChordLululalaShareExtension" target */,
+				DB7CE6012F49A0080061C6C6 /* Exceptions for "ChordLululalaShareExtension" folder in "ChordLululalaShareExtension" target */,
 			);
 			path = ChordLululalaShareExtension;
 			sourceTree = "<group>";

--- a/ChordLululala/ViewModels/ScoreViewModels/ScoreViewModel.swift
+++ b/ChordLululala/ViewModels/ScoreViewModels/ScoreViewModel.swift
@@ -57,7 +57,7 @@ final class ScoreViewModel: ObservableObject{
     @Published var isChordResetModalView: Bool = false
     
     // MARK: 각종 모드
-    @Published var isAnnotationMode: Bool = false
+    @Published var isToolPickerVisible: Bool = false
     @Published var isPlayMode: Bool = false
     @Published var isSinglePageMode = true
     
@@ -436,22 +436,22 @@ final class ScoreViewModel: ObservableObject{
     }
     
     func saveAnnotations() {
-        guard selectedPageIndex < flatPages.count else { return }
-        // flat 인덱스 → (scoreIndex, pageIndex) 로 변환
-        guard let (scoreIdx, pageIdx) = splitFlatIndex(selectedPageIndex) else { return }
+        saveAnnotations(forFlatIndex: selectedPageIndex)
+    }
+
+    func saveAnnotations(forFlatIndex flatIndex: Int) {
+        guard flatIndex < flatPages.count else { return }
+        guard let (scoreIdx, pageIdx) = splitFlatIndex(flatIndex) else { return }
         let scoreContent = scores[scoreIdx]
 
-        // Core Data의 ScorePage 엔티티와 매핑된 로컬 인덱스 페이지
         guard let detail = ScoreDetailManager.shared.fetchDetail(for: scoreContent) else { return }
         let pages = ScorePageManager.shared.fetchPages(for: detail)
         guard pages.indices.contains(pageIdx) else { return }
 
-        // 현재 탭에 표시된 drawing (flat 인덱스로 관리)
-        let drawing = scoreAnnotationViewModel.pageDrawings[selectedPageIndex]
+        let drawing = scoreAnnotationViewModel.pageDrawings[flatIndex]
 
-        // 해당 페이지 하나만 저장
         _ = ScoreAnnotationManager.shared.saveAnnotation(drawing: drawing, for: pages[pageIdx])
-      }
+    }
     
     func resetChords(completion: (() -> Void)? = nil) {
         // 메인 스레드에서 Core Data 작업 수행

--- a/ChordLululala/Views/ScoreViews/CanvasView.swift
+++ b/ChordLululala/Views/ScoreViews/CanvasView.swift
@@ -10,7 +10,7 @@ import PencilKit
 
 struct CanvasView: UIViewRepresentable {
     @Binding var drawing: PKDrawing
-    var isAnnotationMode: Bool
+    var isToolPickerVisible: Bool
     var sharedToolPicker: PKToolPicker
     var originalSize: CGSize
     var displaySize: CGSize
@@ -28,7 +28,7 @@ struct CanvasView: UIViewRepresentable {
         context.coordinator.canvasView = canvasView
         
         DispatchQueue.main.async {
-            if isAnnotationMode {
+            if isToolPickerVisible {
                 canvasView.becomeFirstResponder()
                 sharedToolPicker.setVisible(true, forFirstResponder: canvasView)
                 sharedToolPicker.selectedTool = canvasView.tool
@@ -42,7 +42,7 @@ struct CanvasView: UIViewRepresentable {
             canvasView.drawing = drawing
         }
         
-        if isAnnotationMode {
+        if isToolPickerVisible {
             sharedToolPicker.setVisible(true, forFirstResponder: canvasView)
             canvasView.becomeFirstResponder()
         } else {

--- a/ChordLululala/Views/ScoreViews/ScoreHeaders/ScoreHeaderView.swift
+++ b/ChordLululala/Views/ScoreViews/ScoreHeaders/ScoreHeaderView.swift
@@ -13,8 +13,6 @@ struct ScoreHeaderView: View {
     @EnvironmentObject var viewModel: ScoreViewModel
     @StateObject var orient  = OrientationViewModel()
     
-    @State var isAnnotationMode: Bool = false
-    
     // Pararameter
     @Binding var isRecognized: Bool
     let file : Content
@@ -58,10 +56,9 @@ struct ScoreHeaderView: View {
                 HStack(spacing: 7){
                     /// 펜슬
                     Button(action:{
-                        isAnnotationMode.toggle()
                         toggleAnnotationMode()
                     }){
-                        Image(isAnnotationMode ? "scoreheader_pencil_fill" : "scoreheader_pencil")
+                        Image(viewModel.isToolPickerVisible ? "scoreheader_pencil_fill" : "scoreheader_pencil")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 36, height: 36)

--- a/ChordLululala/Views/ScoreViews/ScoreMainBodyViews/ScoreMainBodyView.swift
+++ b/ChordLululala/Views/ScoreViews/ScoreMainBodyViews/ScoreMainBodyView.swift
@@ -131,13 +131,13 @@ struct ScoreMainBodyView: View {
                                                         annotationViewModel.updateDrawing(newDrawing, forPage: realIndex)
                                                     }
                                                 ),
-                                                isAnnotationMode: viewModel.isAnnotationMode,
+                                                isToolPickerVisible: viewModel.isToolPickerVisible,
                                                 sharedToolPicker: toolPicker,
                                                 originalSize: uiImage.size,
                                                 displaySize: displaySize
                                             )
                                             .frame(width: displaySize.width, height: displaySize.height)
-                                            .allowsHitTesting(viewModel.isAnnotationMode)
+                                            .allowsHitTesting(!viewModel.isPlayMode)
                                         }
                                         .frame(width: displaySize.width, height: displaySize.height)
                                         
@@ -198,6 +198,9 @@ struct ScoreMainBodyView: View {
                 Button {
                     withAnimation {
                         zoomViewModel.reset()
+                        if !viewModel.isPlayMode {
+                            viewModel.isToolPickerVisible = false
+                        }
                         viewModel.isPlayMode.toggle()
                     }
                 } label: {

--- a/ChordLululala/Views/ScoreViews/ScoreView.swift
+++ b/ChordLululala/Views/ScoreViews/ScoreView.swift
@@ -23,7 +23,7 @@ struct ScoreView : View {
                             viewModel.isSetlistOverViewModalView = true
                         },
                         toggleAnnotationMode: {
-                            viewModel.isAnnotationMode.toggle()
+                            viewModel.isToolPickerVisible.toggle()
                         },
                         presentAddPageModal: {
                             viewModel.isAdditionModalView = true
@@ -191,8 +191,11 @@ struct ScoreView : View {
                 }
             }
         }
-        .onChange(of: viewModel.isAnnotationMode) {
-            if !viewModel.isAnnotationMode {
+        .onChange(of: viewModel.selectedPageIndex) { oldIndex, _ in
+            viewModel.saveAnnotations(forFlatIndex: oldIndex)
+        }
+        .onChange(of: viewModel.isToolPickerVisible) {
+            if !viewModel.isToolPickerVisible {
                 NotificationCenter.default.post(name: .endAnnotation, object: nil)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     viewModel.saveAnnotations()


### PR DESCRIPTION
## Summary
- 펜슬 버튼 없이 Apple Pencil로 바로 필기 가능 (연주 모드 제외)
- 연주 모드 ON 시 도구 선택기 자동 해제
- 페이지 전환 시 이전 페이지 필기 자동 저장 (`saveAnnotations(forFlatIndex:)`)
- `isAnnotationMode` → `isToolPickerVisible` 리네이밍
- ScoreHeaderView 로컬 `@State` 제거, ViewModel single source of truth 통일
- ShareExtension Info.plist 중복 빌드 오류 수정

## Test plan
- [ ] Apple Pencil로 악보 터치 → 펜슬 버튼 누르지 않아도 바로 필기 되는지 확인
- [ ] 손가락으로 좌우 스와이프 → 페이지 넘기기 정상 동작 확인
- [ ] 펜슬 버튼 → 도구 선택기만 토글 확인
- [ ] 연주 모드 ON → 필기 비활성 + 도구 선택기 해제 확인
- [ ] 페이지 전환 시 이전 페이지 필기 내용 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)